### PR TITLE
Fix requiring an eponymous module inside a package with a main

### DIFF
--- a/require.js
+++ b/require.js
@@ -575,15 +575,6 @@
                 redirect: normalizeId(description.main),
                 location: config.location
             };
-
-            if (description.name !== modules[""].redirect) {
-                modules[description.name] = {
-                    id: description.name,
-                    redirect: "",
-                    location: URL.resolve(location, description.name)
-                };
-            }
-
         }
 
         //Deal with redirects

--- a/spec/main-name/node_modules/dependency/dependency.js
+++ b/spec/main-name/node_modules/dependency/dependency.js
@@ -1,0 +1,1 @@
+module.exports = true;

--- a/spec/main-name/node_modules/dependency/package.json
+++ b/spec/main-name/node_modules/dependency/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "dependency",
+    "main": "missing.js"
+}

--- a/spec/main-name/package.json
+++ b/spec/main-name/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "dependency": "*"
+    }
+}

--- a/spec/main-name/program.js
+++ b/spec/main-name/program.js
@@ -1,0 +1,6 @@
+var test = require("test");
+var dep = require("dependency/dependency");
+
+test.assert(dep === true, "can require module with name of package");
+test.print("DONE", "info");
+

--- a/spec/require-spec.js
+++ b/spec/require-spec.js
@@ -60,7 +60,8 @@ describe("Require", function () {
         "inject-dependency",
         "inject-mapping",
         "script-injection-dep",
-        "script-injection"
+        "script-injection",
+        "main-name"
     ].forEach(function (test) {
         it(test, function () {
             var spec = this;


### PR DESCRIPTION
I'm not sure of the correctness of this "fix", but I couldn't work out why the redirect from the package name was there. Need your thoughts @kriskowal.
