### PR TITLE
Instrument files on server and generate coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /node_modules
 .idea
 .DS_Store
+lcov.info
+lcov-report/

--- a/node_modules/q
+++ b/node_modules/q
@@ -1,1 +1,0 @@
-../packages/q

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "devDependencies": {
     "qs": "~0.5.3",
     "wd": "~0.0.31",
-    "joey": "~0.1.3"
+    "joey": "~0.1.3",
+    "istanbul": "~0.1.34",
+    "q-io": "~1.6.4"
   },
   "exclude": [
     "README.md",


### PR DESCRIPTION
Run with `npm test --coverage`
