### PR TITLE
Fix main linkage for relative identifiers

### DIFF
--- a/require.js
+++ b/require.js
@@ -590,7 +590,7 @@
             // loaded definition from the given path.
             modules[""] = {
                 id: "",
-                redirect: normalizeId(description.main),
+                redirect: normalizeId(resolve(description.main, "")),
                 location: config.location
             };
 


### PR DESCRIPTION
Previously, a package with a "main" property that started with "./" would be linked incorrectly.
