### PR TITLE
Don't block XHR for the file: protocol

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -34,10 +34,6 @@ function xhrSuccess(req) {
 // http://dl.dropbox.com/u/131998/yui/misc/get/browser-capabilities.html
 Require.read = function (url) {
 
-    if (URL.resolve(window.location, url).indexOf(FILE_PROTOCOL) === 0) {
-        throw new Error("XHR does not function for file: protocol");
-    }
-
     var request = new XMLHttpRequest();
     var response = Promise.defer();
 


### PR DESCRIPTION
Firefox and Safari both natively allow XHR over the file: protocol. Chrome will allow it when the browser is launched with certain command line arguments. If we remove this exception, Montage apps can run from the filesystem without needing a server.
