### PR TITLE
Disable Firebug workaround that breaks modern Firefox

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -73,11 +73,12 @@ Require.read = function (url) {
 // http://www.davidflanagan.com/2010/12/global-eval-in.html
 // Unfortunately execScript doesn't always return the value of the evaluated expression (at least in Chrome)
 var globalEval = /*this.execScript ||*/eval;
-// For Firebug evaled code isn't debuggable otherwise
+
+// For Firebug, evaled code wasn't debuggable otherwise
 // http://code.google.com/p/fbug/issues/detail?id=2198
-if (global.navigator && global.navigator.userAgent.indexOf("Firefox") >= 0) {
-    globalEval = new Function("_", "return eval(_)");
-}
+// if (global.navigator && global.navigator.userAgent.indexOf("Firefox") >= 0) {
+//     globalEval = new Function("return eval(arguments[0])");
+// }
 
 var DoubleUnderscore = "__",
     Underscore = "_",


### PR DESCRIPTION
The workaround is not necessary in modern Firefox, and the argument name
interfered with conditional loading of Underscore in Emmet. I’ve fixed
the issue with the shadowed underscore variable name, and then commented
the workaround out entirely, leaving it in the source just in case it
needs to be uncommented for debugging under older Firebugs, and as a
historical note of how things were.
