### PR TITLE
Don't load devDeps into mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "bin": {
     "mr": "bin/mr"
   },
+  "production": true,
   "mappings": {
     "q": {
       "name": "q",


### PR DESCRIPTION
When loaded as library in the browser (and perhaps in Node.js too) Mr loads its own dependencies into the config mappings. This works for Q, however this also loads the devDependencies which are generally not
installed when Mr is used, and shouldn't override the client's dependencies anyway.

This commit puts Mr into "production" mode, which means it will not read the devDependencies.

To see this problem in action run the following:

```bash
mkdir test
cd test/
npm init
# hit enter lots
npm install --save-dev jasminum
touch a-spec.js
/node_modules/.bin/jasminum-phantom a-spec.js
```

Output:

```
Resource error: http://localhost:52791/~/node_modules/mr/node_modules/qs/package.json
Error: Can't require module "qs" via "phantom/index" because Can't XHR "http://localhost:52791/~/node_modules/mr/node_modules/qs/package.json"
http://localhost:52791/~/node_modules/mr/require.js:185 getExports
http://localhost:52791/~/node_modules/mr/require.js:291
:5 jasminum__phantom_index
http://localhost:52791/~/node_modules/mr/require.js:222 getExports
http://localhost:52791/~/node_modules/mr/require.js:291
http://localhost:52791/~/node_modules/mr/require.js:301
http://localhost:52791/~/node_modules/mr/packages/q/q.js:787 _fulfilled
http://localhost:52791/~/node_modules/mr/packages/q/q.js:816
http://localhost:52791/~/node_modules/mr/packages/q/q.js:749
http://localhost:52791/~/node_modules/mr/packages/q/q.js:557
http://localhost:52791/~/node_modules/mr/packages/q/q.js:108 flush
```