### PR TITLE
Use config object directly in Require.loadPackage

### DIFF
--- a/require.js
+++ b/require.js
@@ -514,9 +514,9 @@
             throw new Error("Can't find dependency: " + JSON.stringify(dependency));
         }
         var location = dependency.location;
-        config = Object.create(config || null);
+        config = config || Object.create(null);
         var loadingPackages = config.loadingPackages = config.loadingPackages || {};
-        var loadedPackages = config.packages = {};
+        var loadedPackages = config.packages = config.packages || {};
         var registry = config.registry = config.registry || new Map;
         config.mainPackageLocation = location;
 


### PR DESCRIPTION
Fixes bug in Mop happening because of the wrong assumption that two
calls to Require.loadPackage with the same config object would share the
config registry.