### PR TITLE
Expose registry in package returned by loadPackage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mr",
-  "version": "16.0.4",
+  "version": "16.0.5",
   "description": "A refresh-only CommonJS module system for browsers, used in Montage",
   "keywords": [
     "montage",

--- a/require.js
+++ b/require.js
@@ -571,7 +571,7 @@
         else {
             pkg = config.loadPackage(dependency);
         }
-
+        pkg.registry = registry;
         pkg.location = location;
         pkg.async = function (id, callback) {
             return pkg.then(function (require) {


### PR DESCRIPTION
This change helps fixing a problem in Mop by allowing it to reuse the
registry of packages/paths created by different Require.loadPackage
calls.

Also updates Mr version.