### PR TITLE
Jshint

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -25,17 +25,18 @@
 
         // determine which scripts to load
         var pending = {
-            "require": "require.js",
-            "require/browser": "browser.js",
+            "require": "node_modules/mr/require.js",
+            "require/browser": "node_modules/mr/browser.js",
             "promise": "node_modules/bluebird/js/browser/bluebird.min.js"
         };
 
         /*jshint -W089 */
         if (!global.preload) {
-            var mrLocation = resolve(window.location, params.mrLocation);
+            var mrLocation = resolve(window.location, params.mrLocation),
+                rootLocation = resolve(window.location, '/');
 
             //Special Case bluebird for now:
-            load(resolve(mrLocation, "node_modules/bluebird/js/browser/bluebird.min.js"),function() {
+            load(resolve(rootLocation, pending.promise),function() {
                 //global.bootstrap cleans itself from window once all known are loaded. "bluebird" is not known, so needs to do it first
                 global.bootstrap("bluebird", function (require, exports) {
                     return window.Promise;
@@ -46,7 +47,9 @@
             });
 
             for (var id in pending) {
-                load(resolve(mrLocation, pending[id]));
+                if (pending.hasOwnProperty(id)) {
+                    load(resolve(rootLocation, pending[id]));
+                }
             }
         }
 
@@ -192,7 +195,9 @@
         var script = document.createElement("script");
         script.src = location;
         script.onload = function () {
-            if(loadCallback) loadCallback(script);
+            if (loadCallback) {
+                loadCallback(script);
+            }
             // remove clutter
             script.parentNode.removeChild(script);
         };

--- a/browser.js
+++ b/browser.js
@@ -77,18 +77,20 @@ onerror.xhrPool = xhrPool;
 function RequireRead(url, module) {
     var xhr = RequireRead.xhrPool.pop();
 
+    function promiseHandler(resolve, reject) {
+        xhr.resolve = resolve;
+        xhr.reject = reject;
+    }
+
     if(!xhr) {
-        xhr = new RequireRead.XMLHttpRequest;
+        xhr = new RequireRead.XMLHttpRequest();
         if (xhr.overrideMimeType) {
             xhr.overrideMimeType(APPLICATION_JAVASCRIPT_MIMETYPE);
         }
         xhr.onload = RequireRead.onload;
         xhr.onerror = RequireRead.onerror;
 
-        function promiseHandler(resolve, reject) {
-            xhr.resolve = resolve;
-            xhr.reject = reject;
-        }
+        
         xhr.promiseHandler = promiseHandler;
     }
     xhr.url = url;
@@ -101,7 +103,8 @@ function RequireRead(url, module) {
     xhr.send(null);
 
     return response;
-};
+}
+
 Require.read = RequireRead;
 RequireRead.xhrPool = xhrPool;
 RequireRead.XMLHttpRequest = XMLHttpRequest;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   "bin": {
     "mr": "bin/mr"
   },
+  "engineStrict" : true,
+  "engines" : { 
+    "npm" : ">=3.0.0" 
+  },
   "production": true,
   "dependencies": {
     "bluebird":"~3.4.6"

--- a/require.js
+++ b/require.js
@@ -1,4 +1,3 @@
-
 /*
     Based in part on Motorola Mobility’s Montage
     Copyright (c) 2012, Motorola Mobility LLC. All Rights Reserved.
@@ -48,12 +47,15 @@
         throw new Error("Require does not work in strict mode.");
     }
 
+    // The global context object
+    var global = this;
+
     var globalEval = eval; // reassigning causes eval to not use lexical scope.
     var ArrayPush = Array.prototype.push;
 
     // Non-CommonJS speced extensions should be marked with an "// EXTENSION"
     // comment.
-    var Map
+    var Map;
     if(!global.Map) {
         Map = function _Map() {
             this._content = Object.create(null);
@@ -68,7 +70,7 @@
         };
         Map.prototype.has = function(key) {
             return  key in this._content;
-        }
+        };
     }
     else {
         Map = global.Map;
@@ -120,7 +122,7 @@
         function getModuleDescriptor(id) {
             var lookupId = isLowercasePattern.test(id) ? id : id.toLowerCase();
             if (!(lookupId in modules)) {
-				var aModule = new _Module;
+				var aModule = new _Module();
                 modules[lookupId] = aModule;
                     aModule.id = id;
                     aModule.display = (config.name || config.location); // EXTENSION
@@ -192,13 +194,10 @@
             .then(function () {
                 // load the transitive dependencies using the magic of
                 // recursion.
-                var module = getModuleDescriptor(topId),
-    				dependencies =  module.dependencies
-					, promises
-					, iModule
-					, depId
-					,dependees
-                    ,iPromise;
+                var promises, iModule, depId, dependees, iPromise,
+                    module = getModuleDescriptor(topId),
+    				dependencies =  module.dependencies;
+
                 if(dependencies && dependencies.length > 0) {
     				for(var i=0;(depId = dependencies[i]);i++) {
                         // create dependees set, purely for debug purposes
@@ -208,16 +207,15 @@
                         //     dependees[topId] = true;
                         // }
                         if((iPromise = deepLoad(normalizeId(resolve(depId, topId)), topId, loading))) {
-                            promises
-                                ? (promises.push ? promises.push(iPromise) : (promises = [promises,iPromise]))
-                                : (promises = iPromise);
+                            promises ? (promises.push ? promises.push(iPromise) : 
+                                    (promises = [promises,iPromise])) : (promises = iPromise);
                         }
         			}
                 }
 
-                return promises
-                        ? (promises.push === void 0 ? promises : Promise.all(promises))
-                        : null;
+                return promises ? (promises.push === void 0 ? promises : 
+                        Promise.all(promises)) : null;
+
             }, function (error) {
                 getModuleDescriptor(topId).error = error;
             });
@@ -310,7 +308,7 @@
             }
 
             var internal = !!seen;
-            seen = seen || new Map;
+            seen = seen || new Map();
             if (seen.has(location)) {
                 return null; // break the cycle of violence.
             }
@@ -517,7 +515,7 @@
         config = Object.create(config || null);
         var loadingPackages = config.loadingPackages = config.loadingPackages || {};
         var loadedPackages = config.packages = {};
-        var registry = config.registry = config.registry || new Map;
+        var registry = config.registry = config.registry || new Map();
         config.mainPackageLocation = location;
 
         config.hasPackage = function (dependency) {
@@ -558,7 +556,7 @@
             if (!loadingPackages[location]) {
                 loadingPackages[location] = Require.loadPackageDescription(dependency, config)
                 .then(function (packageDescription) {
-                    return Require.injectLoadedPackageDescription(location, packageDescription, config)
+                    return Require.injectLoadedPackageDescription(location, packageDescription, config);
                 });
             }
             return loadingPackages[location];
@@ -566,7 +564,7 @@
 
         var pkg;
         if(typeof packageDescription === "object") {
-            pkg = Require.injectLoadedPackageDescription(location, packageDescription, config)
+            pkg = Require.injectLoadedPackageDescription(location, packageDescription, config);
         }
         else {
             pkg = config.loadPackage(dependency);
@@ -687,7 +685,8 @@
         }
 
         // overlay
-        var overlay = description.overlay || {};
+        var redirects,
+            overlay = description.overlay || {};
 
         // but first, convert "browser" field, as pioneered by Browserify, to
         // an overlay
@@ -698,7 +697,7 @@
         } else if (typeof description.browser === "object") {
             var browser = description.browser,
                 browserKeys = Object.keys(browser),
-                bk, iBk, countBk, redirects;
+                bk, iBk, countBk;
 
             overlay.browser = {redirects:{}};
             redirects = overlay.browser.redirects;
@@ -713,11 +712,11 @@
         }
 
         // overlay continued...
-        var layer, overlays, engine;
+        var layer, overlays, engine, name;
         overlays = config.overlays = config.overlays || Require.overlays;
 		for(var i=0, countI=overlays.length;i<countI;i++) {
 			if (layer = overlay[(engine = overlays[i])]) {
-                for (var name in layer) {
+                for (name in layer) {
                     description[name] = layer[name];
                 }
             }
@@ -744,9 +743,9 @@
         }
 
         //Deal with redirects
-        var redirects = description.redirects;
+        redirects = description.redirects;
         if (redirects !== void 0) {
-            for(var r=0, rKeys = Object.keys(redirects), name;(name = rKeys[r]);r++) {
+            for(var r = 0, rKeys = Object.keys(redirects);(name = rKeys[r]);r++) {
                 modules[name] = {
                     id: name,
                     redirect: normalizeId(resolve(redirects[name], name)),
@@ -763,7 +762,7 @@
             processMappingDependencies(description.devDependencies,mappings);
         }
         // mappings
-        for(var m=0, mKeys = Object.keys(mappings), name;(name = mKeys[m]);m++) {
+        for(var m=0, mKeys = Object.keys(mappings);(name = mKeys[m]);m++) {
             mappings[name] = normalizeDependency(
                 mappings[name],
                 config,
@@ -779,8 +778,8 @@
     Require.resolve = resolve;
 
     //We need to find the best time to flush _resolveStringtoArray and _resolved once their content isn't needed anymore
-	var _resolved = new Map;
-	var _resolveStringtoArray = new Map;
+	var _resolved = new Map();
+	var _resolveStringtoArray = new Map();
 	var _target = [];
 
 	function _resolveItem(source, part, target) {
@@ -797,8 +796,10 @@
 	}
 
     function resolve(id, baseId) {
-        if(id === "" && baseId === "") return "";
-		var resolved = _resolved.get(id) || (_resolved.set(id, (resolved = new Map)) && resolved) || resolved;
+        if(id === "" && baseId === "") {
+            return "";
+        }
+		var resolved = _resolved.get(id) || (_resolved.set(id, (resolved = new Map())) && resolved) || resolved;
 		var i, ii;
 		if(!(resolved.has(baseId)) || !(id in resolved.get(baseId))) {
 	        id = String(id);
@@ -815,7 +816,7 @@
 	            resolveItem(source, source[i], _target);
 	        }
             if(!resolved.get(baseId)) {
-                resolved.set(baseId, new Map);
+                resolved.set(baseId, new Map());
             }
 	        resolved.get(baseId).set(id, _target.join("/"));
 	        _target.length = 0;
@@ -1058,17 +1059,15 @@
     var normalizeId = function normalizeId(id) {
         if(!normalizeId.cache.has(id)) {
             var match = normalizeId.normalizePattern.exec(id);
-            normalizeId.cache.set(id,( match
-                                        ? match[1]
-                                        : id));
+            normalizeId.cache.set(id,( match ? match[1] : id));
         }
         return normalizeId.cache.get(id);
     };
-    normalizeId.cache = new Map;
+    normalizeId.cache = new Map();
     normalizeId.normalizePattern = normalizePattern;
 
     var memoize = function (callback, cache) {
-        cache = cache || new Map;
+        cache = cache || new Map();
         function _memoize(key, arg) {
             //return cache[key] || (cache[key] = Promise.try(callback, [key, arg]));
             return _memoize.cache.get(key) || (_memoize.cache.set(key, callback(key, arg))) && _memoize.cache.get(key) || _memoize.cache.get(key);

--- a/require.js
+++ b/require.js
@@ -724,7 +724,8 @@
 		}
         delete description.overlay;
 
-        config.packagesDirectory = URL.resolve(location, "node_modules/");
+        // Since npm 3+ depencencies are not nested unless explicit shrinkwrap 
+        config.packagesDirectory = URL.resolve(location, "/node_modules/");
 
         // The default "main" module of a package has the same name as the
         // package.


### PR DESCRIPTION
> 
> adhoc.js: line 2, col 5, Redefinition of 'URL'.
> 
> bootstrap.js: line 34, col 13, The body of a for in should be wrapped in an if statement to filter unwanted properties from the prototype.
> bootstrap.js: line 202, col 30, Expected '{' and instead saw 'loadCallback'.
> 
> browser.js: line 81, col 31, Missing '()' invoking a constructor.
> browser.js: line 88, col 9, Function declarations should not be placed in blocks. Use a function expression or move the statement to the top of the outer function.
> browser.js: line 104, col 2, Unnecessary semicolon.
> 
> require.js: line 58, col 12, Missing semicolon.
> require.js: line 73, col 10, Missing semicolon.
> require.js: line 125, col 35, Missing '()' invoking a constructor.
> require.js: line 199, col 21, Comma warnings can be turned off with 'laxcomma'.
> require.js: line 198, col 44, Misleading line break before ','; readers may interpret this as an expression boundary.
> require.js: line 199, col 23, Misleading line break before ','; readers may interpret this as an expression boundary.
> require.js: line 200, col 23, Misleading line break before ','; readers may interpret this as an expression boundary.
> require.js: line 201, col 23, Misleading line break before ','; readers may interpret this as an expression boundary.
> require.js: line 202, col 22, Misleading line break before ','; readers may interpret this as an expression boundary.
> require.js: line 214, col 33, Misleading line break before '?'; readers may interpret this as an expression boundary.
> require.js: line 215, col 55, Expected an assignment or function call and instead saw an expression.
> require.js: line 221, col 25, Misleading line break before '?'; readers may interpret this as an expression boundary.
> require.js: line 315, col 32, Missing '()' invoking a constructor.
> require.js: line 522, col 65, Missing '()' invoking a constructor.
> require.js: line 563, col 104, Missing semicolon.
> require.js: line 571, col 95, Missing semicolon.
> require.js: line 722, col 17, The body of a for in should be wrapped in an if statement to filter unwanted properties from the prototype.
> require.js: line 749, col 13, 'redirects' is already defined.
> require.js: line 751, col 58, 'name' is already defined.
> require.js: line 768, col 53, 'name' is already defined.
> require.js: line 784, col 25, Missing '()' invoking a constructor.
> require.js: line 785, col 37, Missing '()' invoking a constructor.
> require.js: line 802, col 40, Expected '{' and instead saw 'return'.
> require.js: line 803, col 80, Missing '()' invoking a constructor.
> require.js: line 820, col 42, Missing '()' invoking a constructor.
> require.js: line 1045, col 13, Expected an assignment or function call and instead saw an expression.
> require.js: line 1064, col 41, Misleading line break before '?'; readers may interpret this as an expression boundary.
> require.js: line 1069, col 29, Missing '()' invoking a constructor.
> require.js: line 1073, col 30, Missing '()' invoking a constructor.
> 