### PR TITLE
Allow to require a deserialized object-descriptor and improvements.

### DIFF
--- a/require.js
+++ b/require.js
@@ -1141,11 +1141,19 @@
     Require.MetaCompiler = function (module) {
         if (module.location && (endsWith(module.location, ".meta") || endsWith(module.location, ".mjson"))) {
             if (typeof module.exports !== "object" && typeof module.text === "string") {
-                if (Require.delegate && typeof Require.delegate.requireWillCompileMJSONFile === "function") {
-                    return Require.delegate.requireWillCompileMJSONFile(
+                if (Require.delegate && typeof Require.delegate.compileMJSONFile === "function") {
+                    return Require.delegate.compileMJSONFile(
                         module.text, module.require, module.id
                     ).then(function (root) {
-                        module.exports = root || JSON.parse(module.text);
+                        module.exports = JSON.parse(module.text);
+                        if (module.exports.montageObject) {
+                            throw new Error(
+                                'using reserved word as property name, \'montageObject\' at: ' +
+                                module.location
+                            );
+                        }
+
+                        module.exports.montageObject = root;
                         return module;
                     });
                 } else {


### PR DESCRIPTION
Deserialized object-descriptor can be directly required on the module’s property name `montageObject`.
Rename delegate method requireWillCompileMJSONFILE to compileMJSONFile.