### PR TITLE
Remove start-of-string designation on comment regExps

### DIFF
--- a/require.js
+++ b/require.js
@@ -959,8 +959,9 @@
 
     // Extracts dependencies by parsing code and looking for "require" (currently using a simple regexp)
     var requirePattern = /(?:^|[^\w\$_.])require\s*\(\s*["']([^"']*)["']\s*\)/g,
-        escapeSimpleComment = /^\/\/.*/gm,
-        escapeMultiComment = /^\/\*[\S\s]*?\*\//gm;
+        escapeSimpleComment = /\/\/(.*)$/gm,
+        escapeMultiComment = /\/\*([\s\S]*?)\*\//g;
+
 
     // Require.parseDependencies = function parseDependencies(factory) {
     //     var o = {};

--- a/test/spec/comments/program.js
+++ b/test/spec/comments/program.js
@@ -29,6 +29,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 </copyright> */
 // require("a");
+ // require("a");
 /* require("b"); */
+ /* require("b"); */
 var test = require('test');
 test.print('DONE', 'info');


### PR DESCRIPTION
Comments were not removed if the leading character is a space. This would result in requests for modules that were only required in comments. 

The issue is remedied by removing the `^` from the start of the comment regular expressions. 

PR includes 2 additional lines in the spec that start a comment line with space
```javascript
// require("a");
 // require("a");
/* require("b"); */
 /* require("b"); */
```