### PR TITLE
Allow Require.delegate to bypass loadScript

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -201,6 +201,7 @@ bootstrap("require/browser", function (require) {
     };
 
     var loadIfNotPreloaded = function (location, definition, preloaded) {
+        var loadScript = Require.delegate && Require.delegate.loadScript || Require.loadScript;
         // The package.json might come in a preloading bundle. If so, we do not
         // want to issue a script injection. However, if by the time preloading
         // has finished the package.json has not arrived, we will need to kick off
@@ -209,13 +210,13 @@ bootstrap("require/browser", function (require) {
             preloaded
             .then(function () {
                 if (definition.isPending()) {
-                    Require.loadScript(location);
+                    loadScript(location);
                 }
             });
         } else if (definition.isPending()) {
             // otherwise preloading has already completed and we don't have the
             // module, so load it
-            Require.loadScript(location);
+            loadScript(location);
         }
     };
 


### PR DESCRIPTION
Provide hook to allow developer to take over script loading. This allows the developer an entry point to do a variety of things without interfering with mr's caching/mapping/redirect, etc. 

### Possible use cases: 
1. Application includes bundles that mr does not recognize. The developer can prevent an unnecessary HTTP request if a file is included in one of said bundles. 

2. Application scripts are stored on the file system and the browser has access. The developer can retrieve the file directly from the system and prevent an unnecessary HTTP request 