### PR TITLE
Add support for loading multiple versions of a package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ atlassian-ide-plugin.xml
 npm-debug.log
 report/
 node_modules/
+!test/spec/**/node_modules/
 out/

--- a/require.js
+++ b/require.js
@@ -248,6 +248,7 @@
 
     var isRelativePattern = /\/$/;
     function normalizeDependency(dependency, config, name) {
+        var versions;
         config = config || {};
         if (typeof dependency === "string") {
             dependency = {
@@ -259,13 +260,12 @@
         }
         // if the named dependency has already been found at another
         // location, refer to the same eventual instance
-        // TODO this has to add a test on version
-        if (
-            dependency.name &&
-                config.registry &&
-                    config.registry.has(dependency.name)
-        ) {
-            dependency.location = config.registry.get(dependency.name);
+        if (dependency.name) {
+            dependency.version = dependency.version || "*";
+            versions = config.registry && config.registry.get(dependency.name);
+            if (versions && versions.has(dependency.version)) {
+                dependency.location = versions.get(dependency.version);
+            }
         }
 
         // default location
@@ -308,7 +308,16 @@
 
         // register the package name so the location can be reused
         if (dependency.name) {
-            config.registry.set(dependency.name,dependency.location);
+            if (!versions) {
+                versions = new Map();
+                config.registry.set(dependency.name, versions);
+            }
+            versions.set(dependency.version, dependency.location);
+            if (dependency.version !== "*") {
+                // Make sure packages who require any version of this dependency get the copy
+                // that is found last (i.e. furthest down in the tree)
+                versions.set("*", dependency.location);
+            }
         }
 
         return dependency;
@@ -352,6 +361,7 @@
 
         var config = Object.create(parent);
         config.name = description.name;
+        config.version = description.version || '*';
         config.location = location || exports.getLocation();
         config.packageDescription = description;
         config.useScriptInjection = description.useScriptInjection;
@@ -367,8 +377,18 @@
         var modules = config.modules = config.modules || {};
 
         var registry = config.registry;
-        if (config.name !== void 0 && !registry.has(config.name)) {
-            registry.set(config.name,config.location);
+        if (config.name !== void 0 && config.version !== void 0) {
+            var versions = registry.get(config.name);
+            if (!versions) {
+                versions = new Map();
+                registry.set(config.name, versions);
+            }
+            if (!versions.has(config.version)) {
+                versions.set(config.version, config.location);
+                if (config.version !== "*") {
+                    versions.set("*", config.location);
+                }
+            }
         }
 
         // overlay

--- a/test/README.md
+++ b/test/README.md
@@ -69,6 +69,12 @@ Verifies that a module can replace its exports by assigning directly to
 Verifies that a module will be executed even if it fails to load.  The
 execution will throw an error.
 
+## multiple-versions
+
+Verifies that dependencies get the correct version of packages they depend
+on when the node_modules tree contains multiple versions of the same
+package.
+
 ## not-found
 
 Verifies that a module will be executed even if it fails to load.  The

--- a/test/all.js
+++ b/test/all.js
@@ -87,6 +87,7 @@ module.exports = run(require, [
     "spec/load-package",
     "spec/load-package-name",
     "spec/load-package-digit",
+    "spec/multiple-versions",
     {name: "spec/not-found", node: false},
     "spec/redirects",
     "spec/redirects-package",

--- a/test/spec/multiple-versions/node_modules/bar/index.js
+++ b/test/spec/multiple-versions/node_modules/bar/index.js
@@ -1,0 +1,3 @@
+var foo = require('foo');
+
+module.exports = foo;

--- a/test/spec/multiple-versions/node_modules/bar/node_modules/foo/index.js
+++ b/test/spec/multiple-versions/node_modules/bar/node_modules/foo/index.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/test/spec/multiple-versions/node_modules/bar/node_modules/foo/package.json
+++ b/test/spec/multiple-versions/node_modules/bar/node_modules/foo/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "foo",
+    "version": "2"
+}

--- a/test/spec/multiple-versions/node_modules/bar/package.json
+++ b/test/spec/multiple-versions/node_modules/bar/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "bar",
+    "version": "1",
+    "dependencies": {
+        "foo": "2"
+    }
+}

--- a/test/spec/multiple-versions/node_modules/foo/index.js
+++ b/test/spec/multiple-versions/node_modules/foo/index.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/test/spec/multiple-versions/node_modules/foo/package.json
+++ b/test/spec/multiple-versions/node_modules/foo/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "foo",
+    "version": "1"
+}

--- a/test/spec/multiple-versions/package.json
+++ b/test/spec/multiple-versions/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "foo": "1",
+        "bar": "1"
+    }
+}

--- a/test/spec/multiple-versions/program.js
+++ b/test/spec/multiple-versions/program.js
@@ -1,0 +1,7 @@
+var test = require('test');
+
+var foo = require('foo');
+var bar = require('bar');
+test.assert(foo === 1);
+test.assert(bar === 2);
+test.print('DONE', 'info');


### PR DESCRIPTION
This is a necessary change to support npm 3+ node_module directories.

Currently mr only keeps the first version found of each package in its registry. Any subsequent packages that depend on a different version of that first package will get the first version loaded instead of the version they asked for, causing unexpected errors.

This also means that depending on the order packages are loaded and under specific (unlikely) situations, mr can fall into an infinite loop, e.g. with a dependency graph that looks like this:

```
    a@1
   /    \
  v      v
 b@1    c@1
  |      |
  v      v
 d@1    d@2
  ^      |
   \     v
    --  e@2     
```

If mr starts loading `e@2` before `d@1`, it will see that it has `d` (`d@2`) in its cache of loading modules, ignoring the requested version and returning `d@2` to `e@2`. Now we have two modules that depend on each other, causing deadlock. The correct behavior is to ignore the `d` from cache because its version does not match the version that `e@2` wants to load.

The situation is ultimately a race condition, and this bug will not reproduce consistently because there is some randomness in how mr loads packages over the network.