### PR TITLE
Ensure packages get the version of a dependency that they asked for

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ atlassian-ide-plugin.xml
 npm-debug.log
 report/
 node_modules/
+!test/spec/**/node_modules
 out/

--- a/require.js
+++ b/require.js
@@ -195,6 +195,8 @@
 
     var isRelativePattern = /\/$/;
     function normalizeDependency(dependency, config, name) {
+        var versions;
+
         config = config || {};
         if (typeof dependency === "string") {
             dependency = {
@@ -206,13 +208,12 @@
         }
         // if the named dependency has already been found at another
         // location, refer to the same eventual instance
-        // TODO this has to add a test on version
-        if (
-            dependency.name &&
-                config.registry &&
-                    config.registry.has(dependency.name)
-        ) {
-            dependency.location = config.registry.get(dependency.name);
+        if (dependency.name) {
+            dependency.version = dependency.version || "*";
+            versions = config.registry && config.registry.get(dependency.name);
+            if (versions && versions.has(dependency.version)) {
+                dependency.location = versions.get(dependency.version);
+            }
         }
 
         // default location
@@ -247,7 +248,16 @@
 
         // register the package name so the location can be reused
         if (dependency.name) {
-            config.registry.set(dependency.name,dependency.location);
+            if (!versions) {
+                versions = new Map();
+                config.registry.set(dependency.name, versions);
+            }
+            versions.set(dependency.version, dependency.location);
+            if (dependency.version !== "*") {
+                // Make sure packages who require any version of this dependency get the copy
+                // that is found last (i.e. furthest down in the tree)
+                versions.set("*", dependency.location);
+            }
         }
 
         return dependency;
@@ -283,6 +293,7 @@
 
         var config = Object.create(parent);
         config.name = description.name;
+        config.version = description.version || "*";
         config.location = location || Require.getLocation();
         config.packageDescription = description;
         config.useScriptInjection = description.useScriptInjection;
@@ -297,8 +308,18 @@
         var modules = config.modules = config.modules || {};
 
         var registry = config.registry;
-        if (config.name !== void 0 && !registry.has(config.name)) {
-            registry.set(config.name,config.location);
+        if (config.name !== void 0 && config.version !== void 0) {
+            var versions = registry.get(config.name);
+            if (!versions) {
+                versions = new Map();
+                registry.set(config.name, versions);
+            }
+            if (!versions.has(config.version)) {
+                versions.set(config.version, config.location);
+                if (config.version !== "*") {
+                    versions.set("*", config.location);
+                }
+            }
         }
 
         // overlay
@@ -1053,8 +1074,8 @@
         "packages",
         "modules"
     ];
-            
-    var syncCompilerChain;    
+
+    var syncCompilerChain;
 
     //The ShebangCompiler doesn't make sense on the client side
     if (typeof window !== "undefined") {
@@ -1099,8 +1120,8 @@
                 )
             );
         };
-    }    
-    
+    }
+
     Require.makeCompiler = function (config) {
         return function (module) {
             return new Promise(function (resolve, reject) {

--- a/test/READMD.md
+++ b/test/READMD.md
@@ -47,6 +47,12 @@ Verifies that a module burried in a directory tree can be required.
 Verifies that an exported object can be imported and exported from
 module to module.
 
+## versions
+
+Verifies that a package gets the correct version of a dependency it
+requested, even if a different version of that dependency was already
+loaded by another package.
+
 
 # CommonJS Modules Amendments
 

--- a/test/all.js
+++ b/test/all.js
@@ -22,10 +22,10 @@ function run(suiteRequire, modules) {
     });
 
     var promises = modules.map(function (module) {
-        
+
         var spec = this,
             packagePath = module + '/';
-        
+
         return suiteRequire.loadPackage(packagePath, {
             location: require.location
         }).then(function (pkg) {
@@ -61,7 +61,7 @@ function run(suiteRequire, modules) {
             if (global.__karma__) {
                 global.__karma__.start();
             } else {
-                jasmine.getEnv().execute();    
+                jasmine.getEnv().execute();
             }
         });
     });
@@ -81,6 +81,7 @@ module.exports = run(require, [
     "spec/transitive",
     "spec/module-exports",
     "spec/return",
+    "spec/versions",
     {name: "spec/named-packages", node: false},
     {name: "spec/named-mappings", node: false},
     "spec/named-parent-package",

--- a/test/spec/versions/node_modules/montage/index.js
+++ b/test/spec/versions/node_modules/montage/index.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/test/spec/versions/node_modules/montage/package.json
+++ b/test/spec/versions/node_modules/montage/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "montage",
+    "version": "1"
+}

--- a/test/spec/versions/node_modules/some-module/index.js
+++ b/test/spec/versions/node_modules/some-module/index.js
@@ -1,0 +1,2 @@
+var montage = require("montage");
+exports.montage = montage;

--- a/test/spec/versions/node_modules/some-module/node_modules/montage/index.js
+++ b/test/spec/versions/node_modules/some-module/node_modules/montage/index.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/test/spec/versions/node_modules/some-module/node_modules/montage/package.json
+++ b/test/spec/versions/node_modules/some-module/node_modules/montage/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "montage",
+    "version": "2"
+}

--- a/test/spec/versions/node_modules/some-module/package.json
+++ b/test/spec/versions/node_modules/some-module/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "some-module",
+    "version": "1",
+    "dependencies": {
+        "montage": "2"
+    }
+}

--- a/test/spec/versions/package.json
+++ b/test/spec/versions/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "montage": "1",
+        "some-module": "1"
+    }
+}

--- a/test/spec/versions/program.js
+++ b/test/spec/versions/program.js
@@ -1,0 +1,34 @@
+/* <copyright>
+Copyright (c) 2012, Motorola Mobility LLC.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Motorola Mobility LLC nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+</copyright> */
+var test = require('test');
+test.assert(require('montage') == 1);
+test.assert(require("some-module").montage == 2);
+test.print('DONE', 'info');


### PR DESCRIPTION
Same PR as #139, except it will apply to master instead of commonjs, since this is not a commonjs-related fix.

Currently mr only keeps the first version found of each package in its registry. Any subsequent packages that depend on a different version of that first package will get the first version loaded instead of the version they asked for, causing unexpected errors.

For example, imaging the following dependency structure:

```
      sample-application
            /    \
montage@0.16.0   some-module
                      |
               montage@0.17.0
```

`montage@0.16.0` will be loaded first and saved in the registry. When `some-module` is deep-loaded, mr will give `montage@0.16.0` to `some-module`, even though `some-module` wants `montage@0.17.0`. `montage@0.17.0` is therefore never loaded, because `mr`'s registry doesn't take version into account.